### PR TITLE
Fix compatibility with open-rpc/meta-schema v0.0.0-20250731032156

### DIFF
--- a/common.go
+++ b/common.go
@@ -31,16 +31,14 @@ var nullSchema meta_schema.JSONSchema
 
 func init() {
 	nullS := "Null"
-
-	var nullT interface{}
-	nullT = "null"
+	nullT := meta_schema.SimpleTypes("null")
 
 	required, deprecated := true, false
 
 	nullSchema = meta_schema.JSONSchema{
 		JSONSchemaObject: &meta_schema.JSONSchemaObject{
 			Type: &meta_schema.Type{
-				SimpleTypes: (*meta_schema.SimpleTypes)(&nullT),
+				SimpleTypes: &nullT,
 			},
 		}}
 

--- a/document.go
+++ b/document.go
@@ -196,9 +196,12 @@ func (d *Document) Discover() (*meta_schema.OpenrpcDocument, error) {
 		return *methods[i].Name < *methods[j].Name
 	})
 
-	// Assign by slice address.
-	m := meta_schema.Methods(methods)
-	out.Methods = &m
+	// Convert []MethodObject to Methods ([]MethodOrReference).
+	methodRefs := make(meta_schema.Methods, len(methods))
+	for i := range methods {
+		methodRefs[i] = meta_schema.MethodOrReference{MethodObject: &methods[i]}
+	}
+	out.Methods = &methodRefs
 
 	return out, nil
 }

--- a/document_test.go
+++ b/document_test.go
@@ -67,7 +67,7 @@ func TestDocument_Discover(t *testing.T) {
 		t.Log(string(b))
 
 		jsonTests := map[string]interface{}{
-			"openrpc":                 "1.2.6",
+			"openrpc":                 "1.3.2",
 			"info.title":              "Calculator API",
 			"info.version":            regexp.MustCompile(time.Now().Format("2006")),
 			"servers.0.url":           listener.Addr().String(),
@@ -108,7 +108,7 @@ func TestDocument_Discover(t *testing.T) {
 		t.Log(str)
 
 		jsonTests := map[string]interface{}{
-			"openrpc":                        "1.2.6",
+			"openrpc":                        "1.3.2",
 			"info.title":                     "Calculator API",
 			"info.version":                   regexp.MustCompile(time.Now().Format("2006")),
 			"servers.0.url":                  listener.Addr().String(),

--- a/examples/example1_test.go
+++ b/examples/example1_test.go
@@ -49,9 +49,9 @@ func (c *MyCalculator) PlusOne(arg *PlusOneArg, reply *PlusOneReply) error {
 	return nil
 }
 
-// ExampleDocument_DiscoverStandard demonstrates a basic application implementation
+// ExampleDocument_Discover demonstrates a basic application implementation
 // of the OpenRPC document service.
-func ExampleDocument_DiscoverStandard() {
+func ExampleDocument_Discover() {
 	calculatorRPCService := new(MyCalculator)
 
 	// Assign a new standard lib rpc server.
@@ -184,10 +184,9 @@ func ExampleDocument_DiscoverStandard() {
 		log.Fatal(err)
 	}
 
-	fmt.Println(*discoverReply.Openrpc)
-	// Output: 1.2.4
-
 	j, _ := json.MarshalIndent(discoverReply, "", "    ")
 	log.Println(string(j))
-	// TADA!
+
+	fmt.Println(*discoverReply.Openrpc)
+	// Output: 1.3.2
 }

--- a/examples/example2_test.go
+++ b/examples/example2_test.go
@@ -12,9 +12,9 @@ import (
 	meta_schema "github.com/open-rpc/meta-schema"
 )
 
-// ExampleDocument_DiscoverStandard2 demonstrates an OpenRPC rpc/document
+// ExampleDocument_Discover_custom demonstrates an OpenRPC rpc/document
 // implementation with a custom configuration.
-func ExampleDocument_DiscoverStandard2() {
+func ExampleDocument_Discover_custom() {
 	calculatorRPCService := new(fakearithmetic.CalculatorRPC)
 
 	// Assign a new standard lib rpc server.

--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,16 @@
 module github.com/etclabscore/go-openrpc-reflect
 
-go 1.21
+go 1.13
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921
 	github.com/etclabscore/go-jsonschema-walk v0.0.6
 	github.com/go-openapi/spec v0.19.11
-	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
-	github.com/stretchr/testify v1.4.0
-	github.com/tidwall/gjson v1.6.0
-)
-
-require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-openapi/jsonpointer v0.19.3 // indirect
-	github.com/go-openapi/jsonreference v0.19.4 // indirect
 	github.com/go-openapi/swag v0.19.11 // indirect
 	github.com/iancoleman/orderedmap v0.1.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tidwall/match v1.0.1 // indirect
-	github.com/tidwall/pretty v1.0.0 // indirect
+	github.com/open-rpc/meta-schema v0.0.0-20250731032156-d8c12c08675d
+	github.com/stretchr/testify v1.4.0
+	github.com/tidwall/gjson v1.6.0
 	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
-github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333 h1:CznVS40zms0Dj5he4ERo+fRPtO0qxUk8lA8Xu3ddet0=
-github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333/go.mod h1:Ag6rSXkHIckQmjFBCweJEEt1mrTPBv8b9W4aU/NQWfI=
+github.com/open-rpc/meta-schema v0.0.0-20250731032156-d8c12c08675d h1:ZNYTz9aScz13ejopZvqRsfgwOtU15OStJjBoNGTZnls=
+github.com/open-rpc/meta-schema v0.0.0-20250731032156-d8c12c08675d/go.mod h1:Ag6rSXkHIckQmjFBCweJEEt1mrTPBv8b9W4aU/NQWfI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/standard_test.go
+++ b/standard_test.go
@@ -255,7 +255,8 @@ func TestStandardReflectorT_GetSchema(t *testing.T) {
 		for k, v := range c.want {
 			switch {
 			case k == "type":
-				assert.Equal(t, v, (*schema.JSONSchemaObject.Type.SimpleTypes))
+				assert.NotNil(t, schema.JSONSchemaObject.Type.SimpleTypes)
+				assert.Equal(t, v, string(*schema.JSONSchemaObject.Type.SimpleTypes))
 			}
 		}
 	}


### PR DESCRIPTION
- SimpleTypes is now a string type: use meta_schema.SimpleTypes("null") directly
- Methods is now []MethodOrReference: wrap each MethodObject in MethodOrReference
- Bump meta-schema dependency to latest